### PR TITLE
Fix incorrect includes=

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph=The astra_esp8266 library provides basic operations to connect with a 
 category=Data Storage
 url=https://github.com/NathanBak/astra_esp8266
 architectures=esp8266,esp32
-includes=src/astra.h
+includes=Astra.h
 depends=Wifi


### PR DESCRIPTION
The `includes=` should not contain the "src" folder, and is case sensitive. It is used by the IDE to insert the `#include <Astra.h>` line when requested and to traverse the dependency tree to identify required libraries.